### PR TITLE
Add dev-mode local login bypass and dev compose/frontend tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 ### Start local instance
 * Start Nginx: `start nginx`
 * Run containers: `./local-run.sh`
+* For local frontend testing, you can skip Google auth by clicking **Continue as Dev User** on the login page when running on `localhost`. (`docker-compose-dev.yml` starts backend with `app.mode=dev`.)
 
 Access the site at http://mmflow.mehtasanket-dev.in/
 

--- a/backend/src/com/mehtasankets/mmflow/app/Application.kt
+++ b/backend/src/com/mehtasankets/mmflow/app/Application.kt
@@ -39,6 +39,10 @@ var verifier: GoogleIdTokenVerifier =
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
+fun isProdMode(): Boolean {
+    return System.getProperty("app.mode", "prod").equals("prod", true)
+}
+
 @Suppress("unused") // Referenced in application.conf
 @kotlin.jvm.JvmOverloads
 fun Application.module(@Suppress("UNUSED_PARAMETER") testing: Boolean = false) {
@@ -63,7 +67,7 @@ fun Application.module(@Suppress("UNUSED_PARAMETER") testing: Boolean = false) {
     }
 
     intercept(ApplicationCallPipeline.Call) {
-        if (!call.request.uri.contains("/login") && System.getProperty("app.mode", "prod").equals("prod", true)) {
+        if (!call.request.uri.contains("/login") && isProdMode()) {
             val authenticationResult = AuthenticationUtil.authenticate(call)
             if (!authenticationResult.first) {
                 call.respondText("Unauthenticated call", status = HttpStatusCode.Unauthorized)
@@ -76,7 +80,7 @@ fun Application.module(@Suppress("UNUSED_PARAMETER") testing: Boolean = false) {
 
             post("/login") {
                 var sessionId = "${UUID.randomUUID()}-${System.currentTimeMillis()}"
-                val user = if (System.getProperty("app.mode", "prod").equals("prod", true)) {
+                val user = if (isProdMode()) {
                     val user = objectMapper.readValue<User>(call.receiveText())
                     val idToken: GoogleIdToken? = withContext(Dispatchers.IO) {
                         verifier.verify(user.idToken)
@@ -216,10 +220,12 @@ fun Application.module(@Suppress("UNUSED_PARAMETER") testing: Boolean = false) {
 }
 
 fun getUser(call: ApplicationCall): User {
-    val userSession = if (System.getProperty("app.mode", "prod").equals("prod", true)) {
-        call.sessions.get(Constants.USER_SESSION_HEADER) as UserSession
-    } else {
-        UserSession("test-123")
+    if (isProdMode()) {
+        val userSession = call.sessions.get(Constants.USER_SESSION_HEADER) as UserSession
+        return loggedInUsersCache[userSession.sessionId]!!
     }
-    return loggedInUsersCache[userSession.sessionId]!!
+
+    val devUserSession = (call.sessions.get(Constants.USER_SESSION_HEADER) as? UserSession) ?: UserSession("test-123")
+    val devUser = User(devUserSession.sessionId, "test-token", "tester", "dev, tester", "")
+    return loggedInUsersCache.getOrPut(devUserSession.sessionId) { devUser }
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,6 +9,7 @@ services:
         environment: 
             - MMFLOW_DB_PATH=/mmflow.db
             - CLIENT_ID
+            - JAVA_TOOL_OPTIONS=-Dapp.mode=dev
         ports:
             - "8090:8090"
         volumes:

--- a/frontend/containers/Login.js
+++ b/frontend/containers/Login.js
@@ -28,6 +28,21 @@ class Login extends Component {
         Window.alert(response)
     }
 
+    isLocalDev = () => {
+        const hostname = window.location.hostname
+        return hostname === 'localhost' || hostname === '127.0.0.1'
+    }
+
+    loginForDev = () => {
+        this.props.UserStore.loginForDev(() => {
+            let destination = '/welcome'
+            if (this.props.location.state && this.props.location.state.from) {
+                destination = this.props.location.state.from
+            }
+            this.props.history.push(destination)
+        })
+    }
+
     render() {
         return <div className='login'>
             <Header {...this.props} />
@@ -39,6 +54,12 @@ class Login extends Component {
                 cookiePolicy={'single_host_origin'}
                 isSignedIn={true}
             />
+            {
+                this.isLocalDev() &&
+                <div style={{ marginTop: '1rem' }}>
+                    <button className="btn btn-secondary" onClick={this.loginForDev}>Continue as Dev User</button>
+                </div>
+            }
         </div >
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "./node_modules/.bin/webpack-dev-server --config ./webpack/webpack.dev.config.js",
     "build": "./node_modules/.bin/webpack --config ./webpack/webpack.prod.config.js && cp index.html dist/index.html",
-    "start": "cd dist/ && ./../node_modules/.bin/http-server"
+    "start": "./node_modules/.bin/serve -s dist -l 8080"
   },
   "author": "mehtasankets (Sanket Mehta)",
   "license": "ISC",
@@ -31,7 +31,8 @@
     "react-pivottable": "^0.11.0",
     "react-plotly.js": "^2.5.1",
     "react-router-dom": "^5.1.2",
-    "recharts": "1.8.5"
+    "recharts": "1.8.5",
+    "serve": "^14.2.5"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/frontend/store/UserStore.js
+++ b/frontend/store/UserStore.js
@@ -29,6 +29,12 @@ class UserStore {
         this.user = defaultUser
         callback()
     }
+
+    @action loginForDev = (callback) => {
+        this.user = new User("test-123", "dev-user", "Local Dev User", "")
+        this.isAuthenticated = true
+        callback()
+    }
 }
 
 const userStore = new UserStore()


### PR DESCRIPTION
### Motivation
- Enable fast local frontend/backend development by bypassing Google OAuth and providing a deterministic dev user when running locally or in a dev Docker compose profile.
- Make it easy to run the frontend static server in modern environments by replacing the old `http-server` start command.

### Description
- Added an `isProdMode()` helper and conditional logic in `backend/src/com/mehtasankets/mmflow/app/Application.kt` to skip real Google auth in non-prod mode and create/return a dev `User` session for local/dev runs.
- Exposed app mode in `docker-compose-dev.yml` by setting `JAVA_TOOL_OPTIONS=-Dapp.mode=dev` so the backend runs in dev mode when using the dev compose file.
- Frontend `frontend/containers/Login.js` now shows a "Continue as Dev User" button on `localhost` and implements `loginForDev` to call a new store action for dev login.
- Added `loginForDev` in `frontend/store/UserStore.js` to set a test user and mark the store as authenticated for local development.
- Updated `frontend/package.json` start script to use `serve -s dist -l 8080` and added `serve` to dependencies.
- Documented the local dev login bypass in `README.md` so developers know they can skip Google auth on `localhost` when using `docker-compose-dev.yml`.

### Testing
- Built the frontend with `npm run build` and the build completed successfully.
- Compiled the backend with a standard Gradle build (`./gradlew build`) and the project compiled successfully.
- Brought up the dev stack with `docker-compose -f docker-compose-dev.yml up --build` and verified the frontend shows the "Continue as Dev User" button on `localhost` and that dev login proceeds into the app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e215365d90832cbf309a3c6f6bf551)